### PR TITLE
Use chrome-buildpack instead full chromium

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -18,6 +18,7 @@ async function createBrowser(opts) {
   }
   browserOpts.headless = !config.DEBUG_MODE;
   browserOpts.args = ['--no-sandbox', '--disable-setuid-sandbox'];
+  browserOpts.executablePath = 'google-chrome';
   if (!opts.enableGPU || navigator.userAgent.indexOf('Win') !== -1) {
     browserOpts.args.push('--disable-gpu');
   }


### PR DESCRIPTION
- Changed buildpack to lighter https://github.com/heroku/heroku-buildpack-google-chrome.git
- Slug size reduced to ~350mb